### PR TITLE
Changes to support tracking states

### DIFF
--- a/lib/stateful.rb
+++ b/lib/stateful.rb
@@ -115,7 +115,7 @@ module Stateful
 
       stateful_fields[options[:name]] = options
 
-      stateful_tracked_fields[options[:name]] = options[:track]
+      stateful_tracked_fields[options[:name]] = options[:track] if options[:track].present?
 
       # define the method that will contain the info objects.
       # we use instance_eval here because its easier to implement the ||= {} logic this way.

--- a/lib/stateful.rb
+++ b/lib/stateful.rb
@@ -50,11 +50,13 @@ module Stateful
   # attempts to set fields about the state change if the state was configured to be tracked
   def track_event(to)
     info = self.class.state_infos[to]
-    tracked_field = info.tracked ? info.name : tracked_parent(info)
-    if tracked_field
-      self["#{tracked_field}_at"] = Time.now
-      self["#{tracked_field}_by"] = User.current if defined?(User) && User.respond_to?(:current)
-      self["#{tracked_field}_value"] = to
+    if info
+      tracked_field = info.tracked ? info.name : tracked_parent(info)
+      if tracked_field
+        self["#{tracked_field}_at"] = Time.now
+        self["#{tracked_field}_by"] = User.current if defined?(User) && User.respond_to?(:current)
+        self["#{tracked_field}_value"] = to
+      end
     end
   end
 

--- a/lib/stateful.rb
+++ b/lib/stateful.rb
@@ -55,7 +55,7 @@ module Stateful
       if tracked_field
         self["#{tracked_field}_at"] = Time.now
         self["#{tracked_field}_by"] = User.current if defined?(User) && User.respond_to?(:current)
-        self["#{tracked_field}_value"] = to
+        self["#{tracked_field}_value"] = to if self.respond_to? "#{tracked_field}_value"
       end
     end
   end
@@ -542,7 +542,7 @@ module Stateful
 
     def init_state_info(name, values, parent = nil)
       values.each do |state_name, config|
-        tracked = @stateful_tracked_fields[name].try(:include?, state_name)
+        tracked = @stateful_tracked_fields[name].try(:include?, state_name) if @stateful_tracked_fields
         info = __send__("#{name}_infos")[state_name] = Stateful::StateInfo.new(self, name, parent, state_name, config, tracked)
         init_state_info(name, config, info) if info.is_group?
       end

--- a/lib/stateful/mongoid.rb
+++ b/lib/stateful/mongoid.rb
@@ -33,8 +33,8 @@ module Stateful
                                  # prevents validation from being called if the state field is redefined in a subclass
                                  if: Proc.new { |_| values == self.class.__send__(values_method_name) }
 
-          # configure scopes to query the attribute value
           __send__("#{options[:name]}_infos").values.each do |info|
+            # configure scopes to query the attribute value
             if info.name != :nil
               states = info.collect_child_states
               prefix = options[:prefix]
@@ -49,6 +49,13 @@ module Stateful
               else
                 scope scope_name, -> { where(name.in => states) }
               end
+            end
+
+            # add tracked fields for this state
+            if info.tracked
+              field("#{info.name}_at", type: Time)
+              field("#{info.name}_by", type: User) if defined?(User)
+              field("#{info.name}_value", type: Symbol)
             end
           end
 

--- a/lib/stateful/mongoid.rb
+++ b/lib/stateful/mongoid.rb
@@ -55,7 +55,7 @@ module Stateful
             if info.tracked
               field("#{info.name}_at", type: Time)
               field("#{info.name}_by", type: User) if defined?(User) && User.respond_to?(:current)
-              field("#{info.name}_value", type: Symbol)
+              field("#{info.name}_value", type: Symbol) if info.is_group?
             end
           end
 

--- a/lib/stateful/mongoid.rb
+++ b/lib/stateful/mongoid.rb
@@ -54,7 +54,7 @@ module Stateful
             # add tracked fields for this state
             if info.tracked
               field("#{info.name}_at", type: Time)
-              field("#{info.name}_by", type: User) if defined?(User)
+              field("#{info.name}_by", type: User) if defined?(User) && User.respond_to?(:current)
               field("#{info.name}_value", type: Symbol)
             end
           end

--- a/lib/stateful/state_info.rb
+++ b/lib/stateful/state_info.rb
@@ -1,9 +1,11 @@
 module Stateful
   class StateInfo
-    attr_reader :parent, :children, :name, :to_transitions
-    def initialize(state_class, attr_name, parent, name, config)
+    attr_reader :parent, :children, :name, :to_transitions, :tracked
+    def initialize(state_class, attr_name, parent, name, config, tracked)
       @attr_name = attr_name
       @state_class = state_class
+      @tracked = tracked
+
       if parent
         @parent = parent
         parent.children << self
@@ -33,6 +35,7 @@ module Stateful
     end
 
     def can_transition_to?(state)
+      return true if Stateful.store[:ignore_state_transition_validations]
       state_info = infos[state]
       if is_group? or state_info.nil? or state_info.is_group?
         false

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -311,28 +311,40 @@ describe Stateful::MongoidIntegration do
   end
 
   describe 'tracking states' do
-    it 'should track changes to parent states' do
-      example.state = :archived
-      example.save
-      expect(example.inactive_value).to eq :archived
-      expect(example.inactive_at).to_not be_nil
+    context 'parent states' do
+      before do
+        example.state = :archived
+        example.save
+      end
+
+      it 'should create mongoid fields' do
+        expect(example).to respond_to(:inactive_at)
+        expect(example).to respond_to(:inactive_value)
+      end
+
+      it 'should track changes to parent states' do
+        expect(example.inactive_value).to eq :archived
+        expect(example.inactive_at).to_not be_nil
+      end
     end
 
-    it 'should track changes to child states' do
-      example.state = :published
-      example.save
-      expect(example.published_value).to eq :published
-      expect(example.published_at).to_not be_nil
-    end
+    context 'child states' do
+      before do
+        example.state = :published
+        example.save
+      end
 
-    it 'should create tracking properties for tracked states' do
-      expect(example).to respond_to(:published_at)
-      expect(example).to respond_to(:published_value)
-      expect(example).to respond_to(:inactive_at)
-      expect(example).to respond_to(:inactive_value)
+      it 'should create mongoid fields' do
+        expect(example).to respond_to(:published_at)
+      end
 
-      expect(example).to_not respond_to(:archived_at)
-      expect(example).to_not respond_to(:archived_value)
+      it 'should track the time' do
+        expect(example.published_at).to_not be_nil
+      end
+
+      it 'should not track value' do
+        expect(example).to_not respond_to(:published_value)
+      end
     end
   end
 

--- a/spec/stateful_spec.rb
+++ b/spec/stateful_spec.rb
@@ -235,8 +235,8 @@ describe Kata do
 
     it 'should support tracked states' do
       expect(Kata.state_infos[:draft].tracked).to be_truthy
-      expect(Kata.state_infos[:beta].tracked).to be_truthy
-      expect(Kata.state_infos[:approved].tracked).to be_truthy
+      expect(Kata.state_infos[:published].tracked).to be_truthy
+      expect(Kata.state_infos[:approved].tracked).to be_falsey
       expect(Kata.state_infos[:needs_approval].tracked).to be_falsey
       expect(Kata.state_infos[:retired].tracked).to be_falsey
     end

--- a/spec/stateful_spec.rb
+++ b/spec/stateful_spec.rb
@@ -20,6 +20,7 @@ class Kata
                 unpublish: :draft,
                 retire: :retired
             },
+            track: [:published, :draft],
             states: {
                 :draft => :beta,
                 published: {
@@ -110,6 +111,7 @@ describe Kata do
   it 'should support state_info' do
     expect(kata.state_info).not_to be_nil
     expect(kata.state_info.name).to eq(:draft)
+    expect(kata.state_info.tracked).to eq(true)
 
     # custom names
     expect(kata.merge_status_info).not_to be_nil
@@ -229,6 +231,14 @@ describe Kata do
 
       # custom
       expect(Kata.merge_status_infos[:na].is?(:na)).to be_truthy
+    end
+
+    it 'should support tracked states' do
+      expect(Kata.state_infos[:draft].tracked).to be_truthy
+      expect(Kata.state_infos[:beta].tracked).to be_truthy
+      expect(Kata.state_infos[:approved].tracked).to be_truthy
+      expect(Kata.state_infos[:needs_approval].tracked).to be_falsey
+      expect(Kata.state_infos[:retired].tracked).to be_falsey
     end
 
     it 'should support expanded to transitions' do


### PR DESCRIPTION
- adds track hash to stateful method allowing tracking parent or child states
- adds tracking fields `#{state}_at`, `#{state}_value, and `#{state}_by (provided `User.current` is available). 
- also allows an override for state transition validations 