### PR TITLE
Exclude group names from valid values

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+name: Test
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    services:
+      mongo:
+        image: mongo:3.6
+        ports:
+          - 27017/tcp
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.5.x'
+      - name: Cache vendor/bundle
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: bundler-${{ hashFiles('stateful.gemspec') }}
+          restore-keys: |
+            bundler-
+      - name: Bundle Install
+        run: |
+          gem install bundler:'< 2'
+          bundle config path vendor/bundle
+          bundle install
+      - name: RSpec
+        run: bundle exec rspec
+        env:
+          MONGO_HOST: localhost:${{ job.services.mongo.ports[27017] }}

--- a/lib/stateful/mongoid.rb
+++ b/lib/stateful/mongoid.rb
@@ -20,7 +20,9 @@ module Stateful
 
         field(name, type: Symbol, default: options[:default]).tap do
           values_method_name = "#{options[:name]}_values"
-          values = __send__("#{options[:name]}_infos").keys
+          values = __send__("#{options[:name]}_infos").each_with_object([]) do |(k, v), ss|
+            ss << k unless v.is_group?
+          end
 
           define_singleton_method(values_method_name) do
             values

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -278,6 +278,8 @@ describe Stateful::MongoidIntegration do
       expect(project.state).to eq(:draft)
       expect(project.merge_status).to eq(:na)
       expect(project.valid?).to be_truthy
+      project.state = :beta
+      expect(project.valid?).to be_falsey
       project.state = :invalid
       expect(project.valid?).to be_falsey
     end

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -3,6 +3,10 @@ require './lib/stateful'
 require 'mongoid'
 require 'mongoid/document'
 
+Mongoid.configure do |config|
+  config.clients.default = { hosts: [ENV['MONGO_HOST']], database: 'test' }
+end
+
 class User
  include Mongoid::Document
 

--- a/stateful.gemspec
+++ b/stateful.gemspec
@@ -19,10 +19,10 @@ to keep things simple.}
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'activesupport'
+  spec.add_dependency 'activesupport', '~> 5.2'
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "mongoid", "~> 3.0"
+  spec.add_development_dependency "mongoid", "~> 6.4"
 
 end


### PR DESCRIPTION
Not sure if this is intentional, but decided to open a PR since I found it while refactoring. 

There's also `nil` in `values` so `allow_nil` option is meaningless (`nil` is allowed when `allow_nil: false`).

Also enables GitHub Actions to see the test result. If this behavior was intentional, I'll open a separate PR.