### PR TITLE
Allow activesupport 6.1

### DIFF
--- a/lib/stateful/version.rb
+++ b/lib/stateful/version.rb
@@ -1,3 +1,3 @@
 module Stateful
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/stateful.gemspec
+++ b/stateful.gemspec
@@ -19,7 +19,7 @@ to keep things simple.}
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'activesupport', '~> 6.0'
+  spec.add_dependency 'activesupport', '>= 6.0'
   spec.add_development_dependency "mongoid", "~> 7.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Upgrading dependencies for Qualified update to Rails 6.1